### PR TITLE
Fix NetworkArtwork.toLocal()

### DIFF
--- a/app/src/main/java/com/ashipo/metropolitanmuseum/ui/model/Artwork.kt
+++ b/app/src/main/java/com/ashipo/metropolitanmuseum/ui/model/Artwork.kt
@@ -103,7 +103,7 @@ private fun NetworkArtwork.getImages(): List<ArtworkImage> {
     }
     val images = mutableListOf<ArtworkImage>()
     val primaryLarge = getLargeImageUrl(primaryImageUrl)
-    val primaryPreview = primaryImagePreviewUrl
+    val primaryPreview = getPreviewImageUrl(primaryImageUrl)
     images.add(ArtworkImage(primaryImageUrl, primaryLarge, primaryPreview))
 
     if (additionalImagesUrls.isNullOrEmpty()) {

--- a/app/src/test/java/com/ashipo/metropolitanmuseum/ui/model/ArtworkTest.kt
+++ b/app/src/test/java/com/ashipo/metropolitanmuseum/ui/model/ArtworkTest.kt
@@ -142,7 +142,8 @@ class ArtworkTest {
         fun `Artwork_images - backed up by images-related NetworkArtwork fields`() {
             val primaryImage =
                 "https://images.metmuseum.org/CRDImages/gr/original/DP-18928-001.jpg"
-            val primaryImagePreview = getPreviewImageUrl(primaryImage)
+            val primaryImagePreview =
+                "https://images.metmuseum.org/CRDImages/gr/web-large/DP-18928-001.jpg"
             val additionalImages = listOf(
                 "https://images.metmuseum.org/CRDImages/gr/original/DP-18928-002.jpg",
                 "https://images.metmuseum.org/CRDImages/gr/original/DP-18928-003.jpg",


### PR DESCRIPTION
Was setting wrong url for the primary image preview